### PR TITLE
Port PAC/FPC converter to Python 3; fix bytes/str handling and add robust UTF‑8/Cyrillic decoding

### DIFF
--- a/UPDATE-2025-11-04.md
+++ b/UPDATE-2025-11-04.md
@@ -1,0 +1,172 @@
+Modified by HaoJi Zhang on 2025-11-04: Port to Python 3, fix bytes/str handling and legacy APIs, add robust UTF-8 decoding and Cyrillic map.
+
+目的與摘要
+- 將 `readPac.py` 自 Python 2 移植至 Python 3。
+- 修正 bytes 與 str 的處理方式、`print` 與 `.iteritems()` 等舊語法。
+- 新增更穩健的 UTF-8 多位元組解碼邏輯與西里爾字母碼表映射；輸出以 UTF-8 寫檔。
+- 修改以Vibe Coding的方式進行，使用模型為Openai gpt-5。
+
+影響檔案
+- `readPac.py`
+
+具體實作與改動細節
+- 檔案讀取
+  - `loadSubtitle()`：改為直接讀取 `bytes`（Python 3 中 `for b in bytes` 取得的是整數）。
+
+- 時碼與位元處理
+  - `getTimeCode()`：以整數索引直接計算高低位（不再使用 `ord()`）。
+  - 所有 `0xFE/0xFF/0x60` 等比較均改為與整數比較（`== 0xFE`）。
+  - `textLength` 計算改為以 bytes 整數相加（取代 `ord()`）。
+
+- 解碼工具函式（皆回傳 Unicode 字串）
+  - `decodeBig5(byte_list)`：保證輸入轉成 `bytes` 後以 `big5` 解碼，失敗回傳空字串。
+  - `getString(encoding, byte_list, index)`：單一位元組以 `bytes([b]).decode(encoding)` 取得字元。
+  - `getUTF8String(encoding, byte_list, index)`：
+    - 依序嘗試 1..4 位元組切片解碼。
+    - 移除控制符 `\u001f` 與 BOM `\ufeff` 後才輸出；若清理後為空則嘗試更長切片。
+  - `getCyrillicString(...)`：
+    - 以內建碼表 `CyrillicCodes` 與 `CyrillicLetters` 建立整數鍵之映射（含單/雙位元組碼）。
+    - 先判斷 ASCII 數字範圍（0x30..0x39），再做單位元組與雙位元組匹配，最後以 `latin-1` 嘗試回退。
+
+- 主要 PAC 解析流程 `getPacParagraph(...)`
+  - while 搜尋段落界標改以整數 byte 比對（`0xFE` 搭配前 12/15 位元處的 `0x60/0x61`）。
+  - `preTextCode` 以 `latin-1` 將 bytes 片段解碼為字串（避免失真）。
+  - `W16` 分支：
+    - 遇到 `0xFE` 插入空白並跳過控制區段；
+    - 非零位元視為 Big5 雙位元組並以 `decodeBig5` 轉字；零位元則取下一位元組作為字元。
+  - 其他 codePage：
+    - `latin` 使用 `iso-8859-1`；`thai` 使用 `cp874`；`utf-8`/`utf8` 使用上述 UTF-8 多位元組邏輯；
+    - `arabic`/`hebrew` 明確列印不支援並 `sys.exit(1)`。
+
+- 文字正規化與編碼偵測
+  - `normalizeText()`：以 `dict.items()` 建立置換表，使用正規表示式批次替換。
+  - `isEncoding()`：
+    - 以 `str.translate` 移除標點與數字；`latin` 以 `isalpha()` 與 Latin-1 區間做合理性檢查；
+    - 其他語系以 Unicode 區段過濾字元；
+    - 長度閾值（短句需 100% 命中，否則 90%）維持原規則；無有效文字則印出提示並離開。
+
+- 輸出與 CLI
+  - `writeOut()`：寫檔一律以 UTF-8；保留 SRT 格式（時間以逗號做毫秒分隔）。
+  - CLI：保留 `optparse`，增加 `outFormat` 為空時的檢查，避免 `None.upper()` 例外。
+
+使用規則與建議
+- 輸入
+  - PAC/FPC 原始檔以二進位方式讀取，不預先以預設編碼解碼。
+  - FPC 預設採用 UTF-8；PAC 可嘗試 `-e latin`、`-e thai`、`-e cyrillic` 等。
+
+- 解碼規則
+  - UTF-8：最多嘗試 4 位元組形成一個字元；自動去除 `\u001f` 與 `\ufeff`。
+  - Big5：`W16` 片段優先；遇到控制位元（`0xFE/0xFF`）會插入空白或跳過控制資訊。
+  - 西里爾：依對應碼表轉換；若無對應，嘗試 `latin-1` 回退。
+
+- 輸出
+  - SRT：序號 + `HH:MM:SS,mmm --> HH:MM:SS,mmm` + 內容，以空行分隔；輸出檔為 UTF-8。
+  - text：僅串接純文字內容。
+
+使用範例
+- 輸出 SRT 到終端機：
+  - `python3 readPac.py -f SRT samples/sample.fpc`
+  - `python3 readPac.py -f SRT samples/sample.pac`
+- 指定編碼：
+  - `python3 readPac.py -f SRT -e utf-8 file.fpc`
+  - `python3 readPac.py -f SRT -e latin file.pac`
+- 輸出到檔案：
+  - `python3 readPac.py -f SRT -o output.srt file.fpc`
+
+相容性與注意事項
+- 自動編碼偵測邏輯延續原設計（只修正 Python 3 相容性），若結果不理想建議手動指定 `-e`。
+- PAC 標準含控制碼與製作習慣差異，少數來源仍可能出現殘留控制字元或空白；可於 `normalizeText()` 擴充替換表。
+
+維護建議
+- 涉及位元解析之區段（例如 `getPacParagraph()`）請以 bytes/整數為單位思考，不要混用 str。
+- 新增語系時，遵循：
+  - 先以單位元組快速解碼；
+  - 多位元組需定義清楚的邊界條件與控制碼過濾；
+  - 盡量回傳 Unicode 字串，避免回傳 UTF-8 bytes。
+
+---
+
+English Version
+
+Summary
+- Port `readPac.py` from Python 2 to Python 3.
+- Fix bytes/str handling and legacy APIs (`print`, `.iteritems()` etc.).
+- Add robust multi-byte UTF-8 decoding and a Cyrillic code map; write output as UTF-8.
+- Changes performed via Vibe Coding using OpenAI GPT-5.
+
+Affected Files
+- `readPac.py`
+
+Implementation Details
+- File Reading
+  - `loadSubtitle()`: read raw `bytes` and treat each element as an int (Python 3 semantics).
+
+- Timecode and Byte Handling
+  - `getTimeCode()`: compute high/low parts directly from integer byte values (no `ord()`).
+  - All byte comparisons use integers (e.g., `== 0xFE`).
+  - `textLength` is computed from byte integers instead of `ord()`.
+
+- Decoder Utilities (all return Unicode strings)
+  - `decodeBig5(byte_list)`: coerce input to `bytes`, decode via `big5`, return empty string on failure.
+  - `getString(encoding, byte_list, index)`: decode a single byte via `bytes([b]).decode(encoding)`.
+  - `getUTF8String(encoding, byte_list, index)`:
+    - Try 1..4-byte slices; decode as UTF-8.
+    - Remove unit separator `\u001f` and BOM `\ufeff` before returning; if cleaned result is empty, try a longer slice.
+  - `getCyrillicString(...)`:
+    - Build an integer-key map from `CyrillicCodes` to `CyrillicLetters` supporting 1- and 2-byte codes.
+    - Prefer ASCII digits (0x30..0x39), then single/dual-byte matches, and finally `latin-1` fallback.
+
+- Main PAC Parsing Flow `getPacParagraph(...)`
+  - Search for paragraph markers using integer byte comparisons (`0xFE` with `0x60/0x61` at -12/-15 positions).
+  - Decode `preTextCode` from a byte slice using `latin-1` to preserve raw bytes.
+  - `W16` branch:
+    - On `0xFE`, insert a space and skip control bytes;
+    - Non-zero byte => Big5 two-byte char via `decodeBig5`; zero byte => take next byte as char.
+  - Other code pages:
+    - `latin` uses `iso-8859-1`; `thai` uses `cp874`; `utf-8`/`utf8` uses the multi-byte UTF-8 logic;
+    - `arabic`/`hebrew` print a clear “Not currently supported” and exit with non-zero.
+
+- Text Normalization and Encoding Detection
+  - `normalizeText()`: build replacement map with `dict.items()` and apply a compiled regex replacement.
+  - `isEncoding()`:
+    - Use `str.translate` to remove punctuation and digits; for `latin`, rely on `isalpha()` and Latin-1 window;
+    - Other languages filter by Unicode block ranges; short lines require 100% hits, others 90%; if no text, print a hint and exit.
+
+- Output and CLI
+  - `writeOut()`: always write files as UTF-8; maintain SRT formatting (comma-separated milliseconds).
+  - CLI: keep `optparse`; guard `outFormat` before `.upper()` to avoid `None.upper()`.
+
+Usage Rules and Tips
+- Input
+  - Read PAC/FPC as binary; do not decode with a default encoding upfront.
+  - Default FPC to UTF-8; for PAC, try `-e latin`, `-e thai`, `-e cyrillic`, etc.
+
+- Decoding Rules
+  - UTF-8: attempt up to 4 bytes per character; strip `\u001f` and `\ufeff`.
+  - Big5: prefer inside `W16` segments; handle control bytes (`0xFE/0xFF`) by inserting spaces or skipping control payloads.
+  - Cyrillic: map via predefined table; if unmapped, fallback to `latin-1`.
+
+- Output
+  - SRT: index + `HH:MM:SS,mmm --> HH:MM:SS,mmm` + content, blank line separated; files are UTF-8.
+  - text: concatenated plain text only.
+
+Examples
+- Print SRT to terminal:
+  - `python3 readPac.py -f SRT samples/sample.fpc`
+  - `python3 readPac.py -f SRT samples/sample.pac`
+- Force encoding:
+  - `python3 readPac.py -f SRT -e utf-8 file.fpc`
+  - `python3 readPac.py -f SRT -e latin file.pac`
+- Write to file:
+  - `python3 readPac.py -f SRT -o output.srt file.fpc`
+
+Compatibility Notes
+- Auto-detection logic stays the same (only ported for Python 3); specify `-e` explicitly if results are suboptimal.
+- PAC often contains control codes and producer-specific quirks; some sources may still leave control remnants or extra spaces—extend `normalizeText()` if needed.
+
+Maintenance Tips
+- For byte-level parsing (e.g., `getPacParagraph()`), think in bytes/ints and avoid mixing in str.
+- When adding a new language:
+  - Try single-byte decoding first;
+  - For multi-byte, define boundaries and control filtering clearly;
+  - Always return Unicode strings, not UTF-8 encoded bytes.

--- a/readPac.py
+++ b/readPac.py
@@ -413,11 +413,9 @@ def getString(encoding, byte_list, index):
 def getUTF8String(encoding, byte_list, index):
     """
     Decode a byte or sequence of bytes (up to 4) with utf-8,
-    return a utf-8 string
+    return a tuple (decoded_text, bytes_consumed).
     """
 
-    # Python 3 path: try 1..4 bytes and decode to str
-    last = ''
     for length in range(1, 5):
         chunk = bytes(byte_list[index: index + length])
         try:
@@ -425,11 +423,11 @@ def getUTF8String(encoding, byte_list, index):
             cleaned = char.replace('\u001f', '').replace('\ufeff', '')
             if cleaned == '':
                 continue
-            return cleaned
+            return cleaned, length
         except UnicodeDecodeError:
-            last = ''
             continue
-    return last
+    # Fallback: consume one byte to progress
+    return '', 1
 
     for idx in range(4):
         byte = byte_list[index: index + idx]
@@ -634,7 +632,7 @@ def getPacParagraph(index, real_bytes, codePage):
 
     if preTextCode == 'W16':
         index += 5
-    while index < len(real_bytes) and index <= maxIndex:
+    while index < len(real_bytes) and index < maxIndex:
         if preTextCode == 'W16':
             if real_bytes[index] == 0xFE:
                 string_buffer += ' '
@@ -646,13 +644,15 @@ def getPacParagraph(index, real_bytes, codePage):
                 if real_bytes[index] == 0:
                     text = bytes(real_bytes[index + 1: index + 2]).decode('latin-1', errors='ignore')
                     string_buffer += text
+                    index += 2
+                    continue
                 else:
                     # Should be Chinese
                     byte_list = real_bytes[index: index + 2]
                     zh_char = decodeBig5(byte_list)
                     string_buffer += zh_char
-
-                index += 1
+                    index += 2
+                    continue
 
         elif real_bytes[index] == 0xFF:
             string_buffer += ' '
@@ -678,7 +678,10 @@ def getPacParagraph(index, real_bytes, codePage):
         elif codePage == 'thai':
             string_buffer += getString('cp874', real_bytes, index)
         elif codePage == 'utf-8' or codePage == 'utf8':
-            string_buffer += getUTF8String('utf-8', real_bytes, index)
+            ch, consumed = getUTF8String('utf-8', real_bytes, index)
+            string_buffer += ch
+            index += consumed
+            continue
         else:
             pass
 

--- a/readPac.py
+++ b/readPac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Date: 2013-12-08
@@ -321,10 +321,8 @@ def loadSubtitle(subtitle_file, codePage):
     """
 
     with open(subtitle_file, 'rb') as inf:
-        block = inf.read()  # read(1024)
-        real_bytes = []
-        for ch in block:
-            real_bytes.append(ch)
+        # Read raw bytes; treat as a bytes object in Python 3
+        real_bytes = inf.read()
 
     index = 0
     all_pars = []
@@ -348,7 +346,7 @@ def normalizeText(text):
     rep = {'çs': 'š', 'çS': 'Š', 'çz': 'ž',
            'çZ': 'Ž', 'çc': 'č', 'çC': 'Č',
            '€': '', '，': '', '？': '', '…': ''}
-    rep = dict((re.escape(k), v) for k, v in rep.iteritems())
+    rep = {re.escape(k): v for k, v in rep.items()}
     pattern = re.compile("|".join(rep.keys()))
     text = pattern.sub(lambda m: rep[re.escape(m.group(0))], text)
 
@@ -359,8 +357,9 @@ def getTimeCode(timeCodeIndex, byte_list):
     """Extract time code"""
 
     if timeCodeIndex > 0:
-        highPart = ord(byte_list[timeCodeIndex]) + ord(byte_list[timeCodeIndex + 1]) * 256
-        lowPart = ord(byte_list[timeCodeIndex + 2]) + ord(byte_list[timeCodeIndex + 3]) * 256
+        # byte_list is a bytes-like object; elements are ints in Python 3
+        highPart = byte_list[timeCodeIndex] + byte_list[timeCodeIndex + 1] * 256
+        lowPart = byte_list[timeCodeIndex + 2] + byte_list[timeCodeIndex + 3] * 256
         highPart = str(highPart).zfill(6)
         lowPart = str(lowPart).zfill(6)
 
@@ -373,7 +372,7 @@ def getTimeCode(timeCodeIndex, byte_list):
 
         milliseconds = int((1000.0 / frameRate) * frames)
 
-        return TimeCode(str(hours).rjust(2,"0"), str(minutes).rjust(2,"0"), str(seconds).rjust(2,"0"), str(milliseconds).rjust(3,"0"))
+        return TimeCode(str(hours).rjust(2, "0"), str(minutes).rjust(2, "0"), str(seconds).rjust(2, "0"), str(milliseconds).rjust(3, "0"))
 
     else:
         return TimeCode(0, 0, 0, 0)
@@ -385,9 +384,17 @@ def decodeBig5(byte_list):
     return big5 char
     """
 
-    zh_char = ''.join(byte_list).decode('big5')
-
-    return zh_char.encode('utf-8')
+    # Ensure we have a bytes object
+    if isinstance(byte_list, (list, tuple)):
+        b = bytes(byte_list)
+    elif isinstance(byte_list, (bytes, bytearray)):
+        b = bytes(byte_list)
+    else:
+        b = bytes([byte_list])
+    try:
+        return b.decode('big5')
+    except UnicodeDecodeError:
+        return ''
 
 
 def getString(encoding, byte_list, index):
@@ -396,12 +403,11 @@ def getString(encoding, byte_list, index):
     return a utf-8 string
     """
 
-    byte = byte_list[index]
+    b = byte_list[index]
     try:
-        char = ''.join(byte).decode(encoding)
-    except UnicodeDecodeError:
-        char = ''
-    return char.encode('utf-8')
+        return bytes([b]).decode(encoding)
+    except Exception:
+        return ''
 
 
 def getUTF8String(encoding, byte_list, index):
@@ -409,6 +415,21 @@ def getUTF8String(encoding, byte_list, index):
     Decode a byte or sequence of bytes (up to 4) with utf-8,
     return a utf-8 string
     """
+
+    # Python 3 path: try 1..4 bytes and decode to str
+    last = ''
+    for length in range(1, 5):
+        chunk = bytes(byte_list[index: index + length])
+        try:
+            char = chunk.decode(encoding)
+            cleaned = char.replace('\u001f', '').replace('\ufeff', '')
+            if cleaned == '':
+                continue
+            return cleaned
+        except UnicodeDecodeError:
+            last = ''
+            continue
+    return last
 
     for idx in range(4):
         byte = byte_list[index: index + idx]
@@ -425,9 +446,47 @@ def getUTF8String(encoding, byte_list, index):
     return char.encode('utf-8')
 
 
+_CYR_MAP = {}
+
+def _init_cyrillic_map():
+    if _CYR_MAP:
+        return
+    for code_str, letter in zip(CyrillicCodes, CyrillicLetters):
+        try:
+            code_int = int(code_str.replace('\\x', ''), 16)
+        except ValueError:
+            continue
+        _CYR_MAP[code_int] = letter
+
 def getCyrillicString(encoding, byte_list, index):
     """Extract Cyrillic string from byte sequence"""
 
+    # Python 3 path using explicit code map
+    _init_cyrillic_map()
+    b = byte_list[index]
+    if isinstance(b, str):
+        # in unlikely case of str, convert to int
+        b = ord(b)
+    if 0x30 <= b <= 0x39:
+        return chr(b)
+    # single byte
+    if b in _CYR_MAP:
+        return _CYR_MAP[b]
+    # try two-byte
+    if len(byte_list) > index + 1:
+        nxt = byte_list[index + 1]
+        if isinstance(nxt, str):
+            nxt = ord(nxt)
+        code = b * 256 + nxt
+        if code in _CYR_MAP:
+            return _CYR_MAP[code]
+
+    try:
+        return bytes([b]).decode('latin-1')
+    except Exception:
+        return ''
+
+    # Legacy code path (Python 2 style) below
     b = byte_list[index]
     if b >= '\x30' and b <= '\x39':
         return b.decode('ascii').encode('utf-8')
@@ -451,10 +510,7 @@ def getCyrillicString(encoding, byte_list, index):
 
 
 def isTarget(correct, paragraphs, min_thresh):
-    if float(correct) / paragraphs > min_thresh:
-        return True
-    else:
-        return False
+    return float(correct) / paragraphs > min_thresh
 
 
 def isEncoding(paragraphs, lang):
@@ -484,8 +540,9 @@ def isEncoding(paragraphs, lang):
         try:
             # Remove punctuation, numbers, euro, and space from text
             removables = string.punctuation + string.digits
-            remove_punct_map = dict((ord(char), None) for char in (removables))
-            text = ''.join([text.decode('utf-8').translate(remove_punct_map)])
+            remove_punct_map = {ord(char): None for char in removables}
+            # entry.text is already str in Python 3
+            text = text.translate(remove_punct_map)
             text = text.replace(' ', '')
 
             # Extract only specific characters from text
@@ -504,8 +561,8 @@ def isEncoding(paragraphs, lang):
 
             # Ratio of chars in unicode block
             if float(len(text)) == 0:
-                 print "Could not determine character encoding from file"
-                 sys.exit(1)
+                print("Could not determine character encoding from file")
+                sys.exit(1)
             
             ratio = float(len(chars)) / float(len(text))
 
@@ -520,8 +577,6 @@ def isEncoding(paragraphs, lang):
                 if ratio >= 0.90:
                     isLang = True
                 else:
-                    #print 'Orig: ', text.encode('utf-8')
-                    #print 'Char: ', chars.encode('utf-8')
                     isLang = False
 
             if isLang:
@@ -544,13 +599,9 @@ def getPacParagraph(index, real_bytes, codePage):
         index += 1
         if index + 20 >= len(real_bytes):
             return None
-        if real_bytes[index] == '\xfe' and \
-           real_bytes[index - 15] == '\x60' or \
-           real_bytes[index - 15] == '\x61':
+        if real_bytes[index] == 0xFE and (real_bytes[index - 15] == 0x60 or real_bytes[index - 15] == 0x61):
             con = False
-        if real_bytes[index] == '\xfe' and \
-           real_bytes[index - 12] == '\x60' or \
-           real_bytes[index - 12] == '\x61':
+        if real_bytes[index] == 0xFE and (real_bytes[index - 12] == 0x60 or real_bytes[index - 12] == 0x61):
             con = False
 
     feIndex = index
@@ -563,37 +614,37 @@ def getPacParagraph(index, real_bytes, codePage):
     p = Paragraph()
     timeStartIndex = feIndex - 15
 
-    if real_bytes[timeStartIndex] == '\x60':
+    if real_bytes[timeStartIndex] == 0x60:
         p.startTime = getTimeCode(timeStartIndex + 1, real_bytes)
         p.endTime = getTimeCode(timeStartIndex + 5, real_bytes)
 
-    elif real_bytes[timeStartIndex + 3] == '\x60':
+    elif real_bytes[timeStartIndex + 3] == 0x60:
         timeStartIndex += 3
         p.startTime = getTimeCode(timeStartIndex + 1, real_bytes)
         p.endTime = getTimeCode(timeStartIndex + 5, real_bytes)
     else:
         return None
 
-    textLength = ord(real_bytes[timeStartIndex + 9]) + ord(real_bytes[timeStartIndex + 10]) * 256
+    textLength = real_bytes[timeStartIndex + 9] + real_bytes[timeStartIndex + 10] * 256
     maxIndex = timeStartIndex + 10 + textLength
 
     string_buffer = ''
     index = feIndex + 3
-    preTextCode = ''.join(real_bytes[index + 1: index + 4])
+    preTextCode = bytes(real_bytes[index + 1: index + 4]).decode('latin-1', errors='ignore')
 
     if preTextCode == 'W16':
         index += 5
     while index < len(real_bytes) and index <= maxIndex:
         if preTextCode == 'W16':
-            if real_bytes[index] == '\xfe':
+            if real_bytes[index] == 0xFE:
                 string_buffer += ' '
-                preTextCode = ''.join(real_bytes[index + 4: index + 7])
+                preTextCode = bytes(real_bytes[index + 4: index + 7]).decode('latin-1', errors='ignore')
                 if preTextCode == 'W16':
                     index += 7
                 index += 2
             else:
-                if ord(real_bytes[index]) == 0:
-                    text = ''.join(real_bytes[index + 1: index + 2])
+                if real_bytes[index] == 0:
+                    text = bytes(real_bytes[index + 1: index + 2]).decode('latin-1', errors='ignore')
                     string_buffer += text
                 else:
                     # Should be Chinese
@@ -603,10 +654,10 @@ def getPacParagraph(index, real_bytes, codePage):
 
                 index += 1
 
-        elif real_bytes[index] == '\xff':
+        elif real_bytes[index] == 0xFF:
             string_buffer += ' '
 
-        elif real_bytes[index] == '\xfe':
+        elif real_bytes[index] == 0xFE:
             string_buffer += ' '
             index += 2
 
@@ -615,11 +666,11 @@ def getPacParagraph(index, real_bytes, codePage):
             latin_char = getString('iso-8859-1', real_bytes, index)
             string_buffer += latin_char
         elif codePage == 'arabic':
-            print 'Not currently supported'
-            exit()
+            print('Not currently supported')
+            sys.exit(1)
         elif codePage == 'hebrew':
-            print 'Not currently supported'
-            exit()
+            print('Not currently supported')
+            sys.exit(1)
         elif codePage == 'cyrillic':
             cyril_char = getCyrillicString('iso-8859-5', real_bytes, index)
             string_buffer += cyril_char
@@ -665,13 +716,12 @@ def writeOut(paragraphs, outForm, file):
             i += 1
 
     if file:
-        target = open(file, 'w')
-        target.write(strRtn)
-        target.close()
+        with open(file, 'w', encoding='utf-8') as target:
+            target.write(strRtn)
     else:
-        print strRtn
+        print(strRtn)
 
-    exit()
+    sys.exit(0)
 
 
 def autoDetect(subtitle_file):
@@ -703,13 +753,13 @@ def main():
     usage = "usage: python readPac.py [options] pac_file"
     availableOutputs = ["SRT","SRT"]
     parser = OptionParser(usage=usage)
-    parser.add_option("-e", "--encoding", dest="codePage",help="encoding: latin, thai, chinese, cyrillic, utf-8")
-    parser.add_option("-t", "--text", action="store_true", dest="textOnly",help="Write out text only")
+    parser.add_option("-e", "--encoding", dest="codePage", help="encoding: latin, thai, chinese, cyrillic, utf-8")
+    parser.add_option("-t", "--text", action="store_true", dest="textOnly", help="Write out text only")
     parser.add_option("-f", "--outformat", dest="outFormat", help="Define output format, options: SRT")
     parser.add_option("-o", "--outfile", dest="outFile", help="Output to file, specify filename")
     (options, args) = parser.parse_args()
-    if options.outFormat.upper() not in availableOutputs:
-        print "Invalid output format: " + options.outFormat
+    if options.outFormat and options.outFormat.upper() not in availableOutputs:
+        print("Invalid output format: " + options.outFormat)
         parser.print_help()
         sys.exit(2)
     elif len(args) == 0:
@@ -733,11 +783,11 @@ def main():
     ##Determine outputs
     ##print options.outFile 
     if options.textOnly:
-         writeOut(paragraphs,"text",options.outFile)
-    elif options.outFormat :
-        writeOut(paragraphs,options.outFormat,options.outFile)
-    else :
-        writeOut(paragraphs,"",options.outFile)
+        writeOut(paragraphs, "text", options.outFile)
+    elif options.outFormat:
+        writeOut(paragraphs, options.outFormat, options.outFile)
+    else:
+        writeOut(paragraphs, "", options.outFile)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Remove Python 2 constructs (print, .iteritems(), ord()-based byte handling).
- Parse timecodes/control codes using integer bytes; compare 0xFE/0xFF/0x60.
- Add multi-byte UTF‑8 decoding with control/BOM stripping (\u001f, \ufeff).
- Implement Cyrillic code map (single/dual‑byte) with latin‑1 fallback.
- Keep auto‑detection logic; make it Python 3–compliant and improve normalization.
- Write SRT as UTF‑8; guard outFormat to avoid None.upper() errors.
- Fix FPC→SRT punctuation transcoding and byte consumption logic to eliminate extra trailing periods and duplicated “(” becoming “((”.
- Add UPDATE-2025-11-04.md documenting the port; changes performed via Vibe Coding using OpenAI GPT‑5.

**將 PAC/FPC 轉檔工具移植至 Python 3，修正 bytes/str 相容性並新增穩健 UTF‑8/西里爾字母解碼**

- 移除 Python 2 相依（print、iteritems、ord 等），統一以 bytes 整數處理
- 修正時碼與控制碼解析；以整數比較 0xFE/0xFF/0x60
- 新增 UTF‑8 多位元組解碼與西里爾字母碼表映射，改善文字正確性
- SRT 輸出採 UTF‑8；CLI guard outFormat，避免 None.upper() 例外
- 修正 FPC→SRT 轉檔的符號轉碼與位元組消耗邏輯，解決每句末尾多出「.」及「(」被重複為「((」的問題
- 新增與說明更新：UPDATE-2025-11-04.md; 修改以Vibe Coding的方式進行，使用模型為 OpenAI GPT‑5